### PR TITLE
created toolkit.h to link all present files of the library toolkit

### DIFF
--- a/include/imesh.h
+++ b/include/imesh.h
@@ -1,3 +1,5 @@
+#include <stdio.h>
+#include "geom.h"
 
 static int ccw( const int ax, const int ay,
                 const int bx, const int by,

--- a/include/toolkit.h
+++ b/include/toolkit.h
@@ -1,0 +1,11 @@
+#ifndef TOOLKIT_H
+#define TOOLKIT_H
+ 
+#include "geom.h"
+#include "imesh.h"
+#include "mesh.h"
+#include "rk4.h"
+#include "utils.h"
+#include "vec.h"
+ 
+#endif 

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,6 +1,0 @@
-
-
-int copy_heap_allocated_array(float *array, int a_size, float *new_array, int na_size) {
-	int a = 0;
-	return 0;
-}

--- a/tests/How-To-Compile.md
+++ b/tests/How-To-Compile.md
@@ -30,3 +30,23 @@ This will yield an error. Why? because we are using the math library. We need to
     gcc mesh_test.o mesh.o geom.o -lm -o executable
 
 And finally, we got it. We create an executable
+
+
+# Create a library named toolkit
+
+create binary objects
+
+	gcc -c ../include/*.h
+	gcc -c ../src/*.c
+
+move to a unique directory
+
+	mv *.o ../obj/
+
+name the library with the first argument and link al binaries (into its own diectory too)
+
+	ar rcs ../lib/toolkit.a ../obj/geom.o ../obj/imesh.o ../obj/mesh.o ../obj/sde.o ../obj/toolkit.o ../obj/vec.o
+
+make sure you also have the binary for your main file, in this case `mesh_test.o` 
+
+	gcc ../obj/mesh_test.o -L../lib -ltoolkit -lm -o ../mesh_test

--- a/tests/mesh_test.c
+++ b/tests/mesh_test.c
@@ -1,9 +1,6 @@
-#include "../include/geom.h" // contains the vertex, edge and triangle structs
-#include "../include/imesh.h"
-#include "../include/mesh.h"
 #include <stdio.h>
 #include <stdlib.h>
-
+#include "../include/toolkit.h"
 
 const int hull_size = 53;
 const float hull[] = {
@@ -65,7 +62,7 @@ const float hull[] = {
 
 void try_imesh() {
 
-        int side = 100;
+        int side = 5;
         int mesh_size;
         float *points = calloc(2*side*side, sizeof(float));
 	//points        = generate_custom_grid(side, hull, hull_size, -0.5, 1);
@@ -117,8 +114,8 @@ void try_bw_mesh() {
 }
 
 int main() {
-	//try_imesh();
-	try_bw_mesh();
+	try_imesh();
+	//try_bw_mesh();
         return 0;
 
 }


### PR DESCRIPTION
this allows to create a bundle toolkit.a which simplifies compilation of test main programs

more information in the recently updated How-To-Compile.md

the directory structure that arises is:
```
build:
libcpt.so  Makefile main

./include:
geom.h      imesh.h      mesh.h      rk4.h      toolkit.h      utils.h      vec.h

./lib:
toolkit.a

./obj:
geom.o  imesh.o  main.o  mesh.o  mesh_test.o  sde.o  toolkit.o  vec.o

./src:
geom.c  imesh.c  main.c  mesh.c  sde.c  vec.c

./tests:
How-To-Compile.md mesh_test.c  sde_tests.c
```
such that `mesh_test.c` only contains a `#include "../include/toolkit.h"` and is compiled with the flags `-lm -ltoolkit` which allow for bundled objects to be used.

note to remember that `libcpt.so` is created as a shared object binary, which allows for interoperability with python via the ctypes library. the `main` executable uses the files at obj/ to with the main program at src/main.c

I understand how this can be complicated to digest, yet it is all very useful for its own purpose.



